### PR TITLE
New mode support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <vertx.jooq.code.version>4.1.0</vertx.jooq.code.version>
         <mysql.version>8.0.15</mysql.version>
 
-        <jwt.version>3.7.0</jwt.version>
+        <jwt.version>3.8.0</jwt.version>
         <reflect.asm.version>1.11.8</reflect.asm.version>
         <asm.version>7.1</asm.version>
         <lombok.version>1.18.6</lombok.version>

--- a/vertx-gaia/vertx-co/src/main/resources/ke/config/vertx-error.yml
+++ b/vertx-gaia/vertx-co/src/main/resources/ke/config/vertx-error.yml
@@ -30,7 +30,7 @@ E40013: You want to send message to event bus, but agent method ({0}) of {1}''s 
 E40014: Zero detected that there is no method of @Queue annotated @Address = {0}, the worker missing
 E40015: Plugin component met error when reading option on key = {0}
 E40016: You enabled the plugin ( key = {0} ), but this plugin has no method of ( public static void init(Vertx) )
-E40017: Worker method signature is wrong, the parameter length must be 1. method = {0}, class = {1}
+E40017: Worker method signature is wrong, the parameter length must be > 0. method = {0}, class = {1}
 E40018: "Async mode: return = {0}, parameter = {1}, valid - Envelop method(Envelop), void method(Message<Envelop>;)"
 E40019: Your plugin {0} met error when starting, please check the details {1}
 E40020: Zero system could not find the config of key = {0}, please check your configurations

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/ZeroHttpWorker.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/ZeroHttpWorker.java
@@ -8,10 +8,10 @@ import io.vertx.up.atom.Envelop;
 import io.vertx.up.atom.worker.Receipt;
 import io.vertx.up.log.Annal;
 import io.vertx.up.micro.follow.Invoker;
+import io.vertx.up.micro.follow.InvokerUtil;
 import io.vertx.up.micro.follow.JetSelector;
 import io.vertx.up.web.ZeroAnno;
 import io.vertx.zero.eon.Values;
-import io.vertx.zero.exception.WorkerArgumentException;
 import io.zero.epic.Ut;
 import io.zero.epic.fn.Fn;
 
@@ -50,7 +50,13 @@ public class ZeroHttpWorker extends AbstractVerticle {
             // 4. Get target reference and method
             final Object reference = receipt.getProxy();
             final Method method = receipt.getMethod();
-            this.verifyArgs(method, this.getClass());
+            /*
+             * In new version, there is not needed to verify
+             * signature of length in arguments, because the new version
+             * will support multi arguments in Worker component
+             * Parameter length must be > 0.
+             */
+            InvokerUtil.verifyArgs(method, this.getClass());
 
             // length = 1
             final Class<?>[] params = method.getParameterTypes();
@@ -88,17 +94,5 @@ public class ZeroHttpWorker extends AbstractVerticle {
             });
             outputMap.forEach((key, value) -> LOGGER.info(Info.MSG_INVOKER, key, Ut.toString(value), String.valueOf(value.size())));
         }
-    }
-
-    private void verifyArgs(final Method method,
-                            final Class<?> target) {
-
-        // 1. Ensure method length
-        final Class<?>[] params = method.getParameterTypes();
-        final Annal logger = Annal.get(target);
-        // 2. The parameters
-        Fn.outUp(Values.ONE != params.length,
-                logger, WorkerArgumentException.class,
-                target, method);
     }
 }

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/AbstractInvoker.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/AbstractInvoker.java
@@ -1,0 +1,59 @@
+package io.vertx.up.micro.follow;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.up.aiki.Ux;
+import io.vertx.up.atom.Envelop;
+import io.vertx.up.log.Annal;
+import io.vertx.up.micro.ipc.client.TunnelClient;
+import io.vertx.zero.eon.Values;
+import io.zero.epic.Ut;
+
+import java.lang.reflect.Method;
+import java.util.function.Function;
+
+/**
+ * Uniform call TunnelClient to remove duplicated codes
+ * Refactor invokder to support Dynamic Invoke
+ */
+@SuppressWarnings("all")
+public abstract class AbstractInvoker implements Invoker {
+
+    protected Annal getLogger() {
+        return Annal.get(this.getClass());
+    }
+
+    /**
+     * Future method(JsonObject)
+     * Future method(JsonArray)
+     */
+    protected Future invokeJson(
+            final Object proxy,
+            final Method method,
+            final Envelop envelop) {
+        final Object reference = envelop.data();
+        final Class<?> argType = method.getParameterTypes()[Values.IDX];
+        final Object arguments = Ut.deserialize(Ut.toString(reference), argType);
+        return Ut.invoke(proxy, method.getName(), arguments);
+    }
+
+    /**
+     *
+     */
+    protected <I> Function<I, Future<Envelop>> nextEnvelop(
+            final Vertx vertx,
+            final Method method) {
+        return item -> this.nextEnvelop(vertx, method, item);
+    }
+
+    protected <T> Future<Envelop> nextEnvelop(
+            final Vertx vertx,
+            final Method method,
+            final T result
+    ) {
+        return TunnelClient.create(this.getClass())
+                .connect(vertx)
+                .connect(method)
+                .send(Ux.to(result));
+    }
+}

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/DynamicInvoker.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/DynamicInvoker.java
@@ -1,21 +1,17 @@
 package io.vertx.up.micro.follow;
 
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonObject;
 import io.vertx.up.aiki.Ux;
 import io.vertx.up.atom.Envelop;
-import io.vertx.up.log.Annal;
-import io.vertx.up.micro.ipc.client.TunnelClient;
 import io.vertx.up.web.ZeroSerializer;
 import io.vertx.zero.eon.Values;
 import io.zero.epic.Ut;
 
 import java.lang.reflect.Method;
 
-public class DynamicInvoker implements Invoker {
-
-    private static final Annal LOGGER = Annal.get(DynamicInvoker.class);
+public class DynamicInvoker extends AbstractInvoker {
 
     @Override
     public void ensure(final Class<?> returnType, final Class<?> paramCls) {
@@ -30,7 +26,7 @@ public class DynamicInvoker implements Invoker {
                        final Method method,
                        final Message<Envelop> message) {
         final Envelop envelop = message.body();
-        LOGGER.info(Info.MSG_FUTURE, this.getClass(), method.getReturnType(), false);
+        this.getLogger().info(Info.MSG_FUTURE, this.getClass(), method.getReturnType(), false);
         final Envelop returnValue = this.executeMethod(proxy, method, envelop);
         message.reply(returnValue);
     }
@@ -38,18 +34,19 @@ public class DynamicInvoker implements Invoker {
     private Envelop executeMethod(final Object proxy,
                                   final Method method,
                                   final Envelop envelop) {
-        // Get type of parameter first element.
-        final Class<?> argType = method.getParameterTypes()[Values.IDX];
-        // Deserialization from message bus.
         final Object returnValue;
-        if (Envelop.class == argType) {
-            // Input type is Envelop, input directly
-            returnValue = Ut.invoke(proxy, method.getName(), envelop);
+        final Class<?> argType = method.getParameterTypes()[Values.IDX];
+        if (Values.ONE == method.getParameterCount()) {
+            if (Envelop.class == argType) {
+                // Input type is Envelop, input directly
+                returnValue = Ut.invoke(proxy, method.getName(), envelop);
+            } else {
+                // One type dynamic here
+                returnValue = this.invokeSingle(proxy, method, envelop);
+            }
         } else {
-            final Object reference = envelop.data();
-            // Non Direct
-            final Object arguments = ZeroSerializer.getValue(argType, Ut.toString(reference));
-            returnValue = Ut.invoke(proxy, method.getName(), arguments);
+            // Multi parameter dynamic here
+            returnValue = this.invokeMulti(proxy, method, envelop);
         }
         // Return type must not be Envelop because top layer has been finished checking.
         return Envelop.success(returnValue);
@@ -61,13 +58,61 @@ public class DynamicInvoker implements Invoker {
                      final Message<Envelop> message,
                      final Vertx vertx) {
         final Envelop envelop = message.body();
-        LOGGER.info(Info.MSG_FUTURE, this.getClass(), method.getReturnType(), true);
+        this.getLogger().info(Info.MSG_FUTURE, this.getClass(), method.getReturnType(), true);
         final Envelop returnValue = this.executeMethod(proxy, method, envelop);
-        TunnelClient.create(this.getClass())
-                .connect(vertx)
-                .connect(method)
-                .send(returnValue)
-                .compose(item -> Future.succeededFuture(Ux.to(item)))
+        this.nextEnvelop(vertx, method, returnValue)
                 .setHandler(Ux.toHandler(message));
+    }
+
+    /**
+     * Invoke with one parameters
+     */
+    private Object invokeMulti(final Object proxy,
+                               final Method method,
+                               final Envelop envelop) {
+        // One type dynamic here
+        final Object reference = envelop.data();
+        // Non Direct
+        final Object[] arguments = new Object[method.getParameterCount()];
+        final JsonObject json = (JsonObject) reference;
+        final Class<?>[] types = method.getParameterTypes();
+        for (int idx = 0; idx < types.length; idx++) {
+            // Value
+            final Object value = json.getValue(String.valueOf(idx));
+            final Class<?> type = types[idx];
+            final Object argument = null == value ? null : ZeroSerializer.getValue(type, value.toString());
+            arguments[idx] = argument;
+        }
+        return Ut.invoke(proxy, method.getName(), arguments);
+    }
+
+    private Object invokeSingle(final Object proxy,
+                                final Method method,
+                                final Envelop envelop) {
+        final Class<?> argType = method.getParameterTypes()[Values.IDX];
+        // One type dynamic here
+        final Object reference = envelop.data();
+        // Non Direct
+        Object parameters = reference;
+        if (JsonObject.class == reference.getClass()) {
+            final JsonObject json = (JsonObject) reference;
+            if (this.isInterface(json)) {
+                // Proxy mode
+                if (Values.ONE == json.fieldNames().size()) {
+                    // New Mode for direct type
+                    parameters = json.getValue("0");
+                }
+            }
+        }
+        final Object arguments = ZeroSerializer.getValue(argType, Ut.toString(parameters));
+        return Ut.invoke(proxy, method.getName(), arguments);
+    }
+
+    private boolean isInterface(final JsonObject json) {
+        final long count = json.fieldNames().stream().filter(Ut::isInteger)
+                .count();
+        // All json keys are numbers
+        this.getLogger().info("[ ZERO ] ( isInterface Mode ) Parameter count: {0}, json: {1}", count, json.encode());
+        return count == json.fieldNames().size();
     }
 }

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/Invoker.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/Invoker.java
@@ -11,9 +11,10 @@ import java.lang.reflect.Method;
  */
 public interface Invoker {
     /**
-     * @param returnType
-     * @param paramCls
-     * @return
+     * Ensure correct invoking
+     *
+     * @param returnType Method return type
+     * @param paramCls   Method parameters
      */
     void ensure(final Class<?> returnType,
                 final Class<?> paramCls);

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/InvokerUtil.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/InvokerUtil.java
@@ -12,7 +12,7 @@ import java.lang.reflect.Method;
  * Tool for invoker do shared works.
  */
 @SuppressWarnings("unused")
-class InvokerUtil {
+public class InvokerUtil {
     /**
      * Whether this method is void
      *
@@ -26,20 +26,22 @@ class InvokerUtil {
 
     /**
      * Arguments verification
+     * Public for replacing duplicated code
      *
      * @param method checked method.
      * @param target checked class
      */
-    static void verifyArgs(final Method method,
-                           final Class<?> target) {
+    public static void verifyArgs(final Method method,
+                                  final Class<?> target) {
 
         // 1. Ensure method length
         final Class<?>[] params = method.getParameterTypes();
         final Annal logger = Annal.get(target);
         // 2. The parameters
-        Fn.outUp(Values.ONE != params.length,
+        Fn.outUp(Values.ZERO == params.length,
                 logger, WorkerArgumentException.class,
                 target, method);
+
     }
 
     static void verify(

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/MessageInvoker.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/MessageInvoker.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 /**
  * void method(Messsage<Envelop>)
  */
-public class MessageInvoker implements Invoker {
+public class MessageInvoker extends AbstractInvoker {
     @Override
     public void ensure(final Class<?> returnType,
                        final Class<?> paramCls) {

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/PingInvoker.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/follow/PingInvoker.java
@@ -11,7 +11,7 @@ import java.lang.reflect.Method;
 /**
  * void method(Envelop)
  */
-public class PingInvoker implements Invoker {
+public class PingInvoker extends AbstractInvoker {
 
     @Override
     public void ensure(final Class<?> returnType,

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/ipc/server/UnityTunnel.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/micro/ipc/server/UnityTunnel.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 /**
- * Unity tunnel
+ * Unity nextTunnel
  */
 public class UnityTunnel implements Tunnel {
 

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/MediaResolver.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/MediaResolver.java
@@ -64,7 +64,8 @@ class MediaResolver {
                                 .filter(Objects::nonNull)
                                 .map(MediaType::valueOf)
                                 .filter(Objects::nonNull)
-                                .subscribe(result::add);
+                                .subscribe(result::add)
+                                .dispose();
                         return result.isEmpty() ? DEFAULTS : result;
                     });
         }, method, mediaCls);

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/MethodResolver.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/MethodResolver.java
@@ -32,6 +32,7 @@ class MethodResolver {
                 }
             };
 
+    @SuppressWarnings("all")
     public static HttpMethod resolve(final Method method) {
         // 1. Method checking.
         Fn.outUp(null == method, LOGGER,

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/PathResolver.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/PathResolver.java
@@ -81,8 +81,8 @@ class PathResolver {
      * 2. Append the '/' to first;
      * 3. Replaced all duplicated '//';
      *
-     * @param path
-     * @return
+     * @param path input path no normalized.
+     * @return calculated uri
      */
     private static String calculate(final String path) {
         String uri = path;

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/Verifier.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/config/Verifier.java
@@ -1,0 +1,26 @@
+package io.vertx.up.rs.config;
+
+import io.vertx.up.log.Annal;
+import io.vertx.zero.exception.AccessProxyException;
+import io.vertx.zero.exception.NoArgConstructorException;
+import io.zero.epic.Ut;
+import io.zero.epic.fn.Fn;
+
+import java.lang.reflect.Modifier;
+
+class Verifier {
+
+    static void noArg(final Class<?> clazz, final Class<?> target) {
+        final Annal logger = Annal.get(target);
+        Fn.outUp(!Ut.withNoArgConstructor(clazz), logger,
+                NoArgConstructorException.class,
+                logger, clazz);
+    }
+
+    static void modifier(final Class<?> clazz, final Class<?> target) {
+        final Annal logger = Annal.get(target);
+        Fn.outUp(!Modifier.isPublic(clazz.getModifiers()), logger,
+                AccessProxyException.class,
+                target, clazz);
+    }
+}

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/router/DynamicAxis.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/rs/router/DynamicAxis.java
@@ -47,7 +47,8 @@ public class DynamicAxis implements Axis<Router> {
             plugRouter.mount(router, routerConfig);
         } else {
             if (Values.ONE == LOG_FLAG_END.getAndIncrement()) {
-                LOGGER.info(Info.DY_SKIP, NAME, Fn.getNull(null, clazz::getName, clazz));
+                LOGGER.info(Info.DY_SKIP, NAME,
+                        Fn.getNull(null, () -> null == clazz ? null : clazz.getName(), clazz));
             }
         }
     }

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/web/ZeroAnno.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/web/ZeroAnno.java
@@ -89,14 +89,9 @@ public class ZeroAnno {
                 });
 
         /* Ipc Only **/
-        Fn.safeSemi(IPCS.isEmpty(),
-                LOGGER,
-                () -> {
-                    final Inquirer<ConcurrentMap<String, Method>> ipc =
-                            Ut.singleton(IpcInquirer.class);
-                    IPCS.putAll(ipc.scan(clazzes));
-                });
-
+        final Inquirer<ConcurrentMap<String, Method>> ipc =
+                Ut.singleton(IpcInquirer.class);
+        IPCS.putAll(ipc.scan(clazzes));
         /* Agent **/
         final Inquirer<ConcurrentMap<ServerType, List<Class<?>>>> agent =
                 Ut.singleton(AgentInquirer.class);

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/web/anima/Verticles.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/web/anima/Verticles.java
@@ -36,6 +36,9 @@ class Verticles {
                         flag);
                 INSTANCES.put(clazz, result.result());
             } else {
+                if (null != result.cause()) {
+                    result.cause().printStackTrace();
+                }
                 logger.warn(Info.VTC_FAIL,
                         name, option.getInstances(), result.result(),
                         null == result.cause() ? null : result.cause().getMessage(), flag);

--- a/vertx-gaia/vertx-up/src/main/java/io/vertx/up/web/origin/ReceiptInquirer.java
+++ b/vertx-gaia/vertx-up/src/main/java/io/vertx/up/web/origin/ReceiptInquirer.java
@@ -11,7 +11,8 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * @Receipt
+ * Receipt annotation inquirer
+ * This thread is for Receipt extraction
  */
 public class ReceiptInquirer implements Inquirer<Set<Receipt>> {
 
@@ -20,20 +21,20 @@ public class ReceiptInquirer implements Inquirer<Set<Receipt>> {
     @Override
     public Set<Receipt> scan(final Set<Class<?>> queues) {
         final List<QueueThread> threadReference = new ArrayList<>();
-        /** 3.1. Build Metadata **/
+        /* 3.1. Build Metadata **/
         for (final Class<?> queue : queues) {
             final QueueThread thread =
                     new QueueThread(queue);
             threadReference.add(thread);
             thread.start();
         }
-        /** 3.2. Join **/
+        /* 3.2. Join **/
         Fn.safeJvm(() -> {
             for (final QueueThread item : threadReference) {
                 item.join();
             }
         }, LOGGER);
-        /** 3.3. Return **/
+        /* 3.3. Return **/
         final Set<Receipt> receipts = new HashSet<>();
         Fn.safeJvm(() -> {
             for (final QueueThread item : threadReference) {

--- a/vertx-zeus/up-uranus/src/main/java/up/god/test/ParamAgent.java
+++ b/vertx-zeus/up-uranus/src/main/java/up/god/test/ParamAgent.java
@@ -1,0 +1,22 @@
+package up.god.test;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.up.annotations.Address;
+import io.vertx.up.annotations.EndPoint;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@EndPoint
+@Path("/api")
+public class ParamAgent {
+    @Path("/test/params2")
+    @GET
+    @Address("TEST://EVENT2")
+    public JsonObject direct(@QueryParam("first") final String first,
+                             @QueryParam("second") final String second) {
+        return new JsonObject().put("first", first)
+                .put("second", second);
+    }
+}

--- a/vertx-zeus/up-uranus/src/main/java/up/god/test/ParamApi.java
+++ b/vertx-zeus/up-uranus/src/main/java/up/god/test/ParamApi.java
@@ -1,0 +1,24 @@
+package up.god.test;
+
+import io.vertx.up.annotations.Address;
+import io.vertx.up.annotations.EndPoint;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@EndPoint
+@Path("/api")
+public interface ParamApi {
+
+    @Path("/test/params")
+    @GET
+    @Address("TEST://EVENT")
+    String direct(@QueryParam("first") String first,
+                  @QueryParam("second") String second);
+
+    @Path("/test/params1")
+    @GET
+    @Address("TEST://EVENT1")
+    String onlyone(@QueryParam("first") String first);
+}

--- a/vertx-zeus/up-uranus/src/main/java/up/god/test/ParamWorker.java
+++ b/vertx-zeus/up-uranus/src/main/java/up/god/test/ParamWorker.java
@@ -1,0 +1,25 @@
+package up.god.test;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.up.annotations.Address;
+import io.vertx.up.annotations.Queue;
+
+@Queue
+public class ParamWorker {
+
+    @Address("TEST://EVENT")
+    public JsonObject direct(final String first, final String second) {
+        return new JsonObject().put("first", first)
+                .put("second", second);
+    }
+
+    @Address("TEST://EVENT1")
+    public JsonObject onlyOne(final String first) {
+        return new JsonObject().put("first", first);
+    }
+
+    @Address("TEST://EVENT2")
+    public JsonObject direct1(final JsonObject params) {
+        return params;
+    }
+}


### PR DESCRIPTION
移除不必要的重复性代码，支持新的Worker写法：

```java
    // 新写法，直接匹配
    @Address("TEST://EVENT")
    public JsonObject direct(final String first, final String second) {
        return new JsonObject().put("first", first)
                .put("second", second);
    }

    @Address("TEST://EVENT1")
    public JsonObject onlyOne(final String first) {
        return new JsonObject().put("first", first);
    }
    // 旧写法，方法签名只能带一个参数，并且这个参数必须是Envelop或其他类型
    @Address("TEST://EVENT2")
    public JsonObject direct1(final JsonObject params) {
        return params;
    }
```