### PR TITLE
Uniform version for core dep

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- RC Version Ok -->
         <jackson.version>2.12.2</jackson.version>
         <jackson.extension.version>2.12.2</jackson.extension.version>
-        <protobuf.version>3.15.6</protobuf.version>
+        <protobuf.version>3.11.4</protobuf.version>
 
         <!-- Java Projection Basic Configuration -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -101,7 +101,7 @@
         <guice.version>4.1.0</guice.version>
         <scala.version>2.13.5</scala.version>
         <feign.version>8.18.0</feign.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>25.1-jre</guava.version>
         <joda.version>2.10.10</joda.version>
         <codehaus.janino.version>3.2.1</codehaus.janino.version>
         <codehaus.mojo.version>1.20</codehaus.mojo.version>
@@ -146,7 +146,7 @@
         <!-- Vert.x Addition -->
         <rxjava2.version>2.2.21</rxjava2.version>
         <netty.tcnative.version>2.0.36.Final</netty.tcnative.version>
-        <netty.version>4.1.54.Final</netty.version>
+        <netty.version>4.1.49.Final</netty.version>
         <hazelcast.version>3.12.12</hazelcast.version>
         <swagger.version>1.6.0</swagger.version>
         <error.prone.version>2.5.1</error.prone.version>
@@ -262,11 +262,31 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-codegen</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-web</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-auth-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
@@ -282,11 +302,75 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-config-yaml</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-yaml</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-core</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-transport</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-handler-proxy</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http2</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-handler</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-resolver</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-resolver-dns</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-buffer</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
@@ -297,11 +381,27 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-hazelcast</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.hazelcast</groupId>
+                        <artifactId>hazelcast</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-unit</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
@@ -322,10 +422,29 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-health-check</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-web</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-auth-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-auth</artifactId>
+                <version>${vertx.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vertx</groupId>
+                <artifactId>vertx-auth-common</artifactId>
                 <version>${vertx.version}</version>
             </dependency>
             <dependency>
@@ -337,6 +456,16 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-auth-jwt</artifactId>
                 <version>${vertx.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-auth-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.vertx</groupId>
@@ -412,6 +541,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-jexl3</artifactId>
                 <version>${common.jexl.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
             <dependency>
@@ -485,6 +620,16 @@
                 <groupId>io.github.jklingsporn</groupId>
                 <artifactId>vertx-jooq-future</artifactId>
                 <version>${vertx.jooq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.github.jklingsporn</groupId>
@@ -494,6 +639,18 @@
                     <exclusion>
                         <groupId>io.github.jklingsporn</groupId>
                         <artifactId>vertx-jooq-shared</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq-codegen</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -586,6 +743,16 @@
                 <groupId>com.hazelcast</groupId>
                 <artifactId>hazelcast</artifactId>
                 <version>${hazelcast.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.hazelcast</groupId>
+                        <artifactId>hazelcast</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/io.netty/netty-tcnative-boringssl-static -->
             <dependency>
@@ -666,7 +833,15 @@
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -679,6 +854,10 @@
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -686,6 +865,10 @@
                 <artifactId>jackson-dataformat-cbor</artifactId>
                 <version>${jackson.extension.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
@@ -696,28 +879,82 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-parameter-names</artifactId>
                 <version>${jackson.extension.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jdk8</artifactId>
                 <version>${jackson.extension.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-jsr310</artifactId>
                 <version>${jackson.extension.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-afterburner -->
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-afterburner</artifactId>
                 <version>${jackson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
             <dependency>
@@ -743,6 +980,12 @@
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflection.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.javassist</groupId>
+                        <artifactId>javassist</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- http://mvnrepository.com/artifact/junit/junit -->
             <dependency>
@@ -851,6 +1094,20 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/com.netflix.feign/feign-core -->
             <dependency>
@@ -885,6 +1142,14 @@
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/cglib/cglib -->
@@ -892,6 +1157,12 @@
                 <groupId>cglib</groupId>
                 <artifactId>cglib</artifactId>
                 <version>${cglib.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/javax.cache/cache-api -->
             <dependency>
@@ -940,17 +1211,39 @@
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
                 <version>${hikari.cp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.jooq/jooq-codegen -->
             <dependency>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-codegen</artifactId>
                 <version>${jooq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq-meta</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jooq</groupId>
                 <artifactId>jooq-meta</artifactId>
                 <version>${jooq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jooq</groupId>
@@ -962,6 +1255,12 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
                 <version>${netty.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-transport</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -997,11 +1296,23 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
                 <version>${netty.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-resolver</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
                 <version>${netty.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -1024,6 +1335,16 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
                 <version>${netty.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-resolver</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-buffer</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -1046,12 +1367,32 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${http.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime -->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${http.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore -->
             <dependency>

--- a/vertx-gaia/vertx-co/pom.xml
+++ b/vertx-gaia/vertx-co/pom.xml
@@ -16,16 +16,6 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-codegen</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-net</groupId>
@@ -38,103 +28,24 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-auth-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-config-yaml</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- Codec -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-resolver</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-buffer</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Hazelcast -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-hazelcast</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Unit Testing -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-unit</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -163,97 +74,31 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- Jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -276,12 +121,6 @@
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.ow2.asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -291,26 +130,10 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -368,35 +191,11 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec-dns</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-resolver</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -418,18 +217,7 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq-codegen</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq-meta</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jooq</groupId>
-            <artifactId>jooq</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/vertx-gaia/vertx-tp/pom.xml
+++ b/vertx-gaia/vertx-tp/pom.xml
@@ -19,41 +19,15 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- JooQ -->
         <dependency>
             <groupId>io.github.jklingsporn</groupId>
             <artifactId>vertx-jooq-future</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jooq</groupId>
-                    <artifactId>jooq</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.github.jklingsporn</groupId>
             <artifactId>vertx-jooq-generate</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jooq</groupId>
-                    <artifactId>jooq</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
@@ -64,32 +38,21 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-health-check</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-web</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-auth-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Jwt -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-jwt</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <!-- Jooq -->
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq-codegen</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq-meta</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/vertx-gaia/vertx-up/pom.xml
+++ b/vertx-gaia/vertx-up/pom.xml
@@ -43,6 +43,11 @@
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
         </dependency>
+        <!-- Auth Common Framework for different Authorization -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-auth-common</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcContent.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcContent.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.IpcContent}
  */
-public final class IpcContent extends
+public  final class IpcContent extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.IpcContent)
     IpcContentOrBuilder {
@@ -93,7 +93,6 @@ private static final long serialVersionUID = 0L;
    * <code>string value = 1;</code>
    * @return The value.
    */
-  @java.lang.Override
   public java.lang.String getValue() {
     java.lang.Object ref = value_;
     if (ref instanceof java.lang.String) {
@@ -110,7 +109,6 @@ private static final long serialVersionUID = 0L;
    * <code>string value = 1;</code>
    * @return The bytes for value.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString
       getValueBytes() {
     java.lang.Object ref = value_;

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcEnvelop.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcEnvelop.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.IpcEnvelop}
  */
-public final class IpcEnvelop extends
+public  final class IpcEnvelop extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.IpcEnvelop)
     IpcEnvelopOrBuilder {
@@ -117,7 +117,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Format type = 1;</code>
    * @return The enum numeric value on the wire for type.
    */
-  @java.lang.Override public int getTypeValue() {
+  public int getTypeValue() {
     return type_;
   }
   /**
@@ -128,7 +128,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Format type = 1;</code>
    * @return The type.
    */
-  @java.lang.Override public io.vertx.tp.ipc.eon.em.Format getType() {
+  public io.vertx.tp.ipc.eon.em.Format getType() {
     @SuppressWarnings("deprecation")
     io.vertx.tp.ipc.eon.em.Format result = io.vertx.tp.ipc.eon.em.Format.valueOf(type_);
     return result == null ? io.vertx.tp.ipc.eon.em.Format.UNRECOGNIZED : result;
@@ -144,7 +144,6 @@ private static final long serialVersionUID = 0L;
    * <code>string body = 2;</code>
    * @return The body.
    */
-  @java.lang.Override
   public java.lang.String getBody() {
     java.lang.Object ref = body_;
     if (ref instanceof java.lang.String) {
@@ -165,7 +164,6 @@ private static final long serialVersionUID = 0L;
    * <code>string body = 2;</code>
    * @return The bytes for body.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString
       getBodyBytes() {
     java.lang.Object ref = body_;
@@ -190,7 +188,6 @@ private static final long serialVersionUID = 0L;
    * <code>bytes stream = 3;</code>
    * @return The stream.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString getStream() {
     return stream_;
   }
@@ -205,7 +202,6 @@ private static final long serialVersionUID = 0L;
    * <code>string name = 4;</code>
    * @return The name.
    */
-  @java.lang.Override
   public java.lang.String getName() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
@@ -226,7 +222,6 @@ private static final long serialVersionUID = 0L;
    * <code>string name = 4;</code>
    * @return The bytes for name.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString
       getNameBytes() {
     java.lang.Object ref = name_;
@@ -602,7 +597,7 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Format type = 1;</code>
      * @return The enum numeric value on the wire for type.
      */
-    @java.lang.Override public int getTypeValue() {
+    public int getTypeValue() {
       return type_;
     }
     /**
@@ -615,7 +610,6 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setTypeValue(int value) {
-      
       type_ = value;
       onChanged();
       return this;
@@ -628,7 +622,6 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Format type = 1;</code>
      * @return The type.
      */
-    @java.lang.Override
     public io.vertx.tp.ipc.eon.em.Format getType() {
       @SuppressWarnings("deprecation")
       io.vertx.tp.ipc.eon.em.Format result = io.vertx.tp.ipc.eon.em.Format.valueOf(type_);
@@ -772,7 +765,6 @@ private static final long serialVersionUID = 0L;
      * <code>bytes stream = 3;</code>
      * @return The stream.
      */
-    @java.lang.Override
     public com.google.protobuf.ByteString getStream() {
       return stream_;
     }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcRequest.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcRequest.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.IpcRequest}
  */
-public final class IpcRequest extends
+public  final class IpcRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.IpcRequest)
     IpcRequestOrBuilder {
@@ -152,7 +152,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Format response_format = 1;</code>
    * @return The enum numeric value on the wire for responseFormat.
    */
-  @java.lang.Override public int getResponseFormatValue() {
+  public int getResponseFormatValue() {
     return responseFormat_;
   }
   /**
@@ -163,7 +163,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Format response_format = 1;</code>
    * @return The responseFormat.
    */
-  @java.lang.Override public io.vertx.tp.ipc.eon.em.Format getResponseFormat() {
+  public io.vertx.tp.ipc.eon.em.Format getResponseFormat() {
     @SuppressWarnings("deprecation")
     io.vertx.tp.ipc.eon.em.Format result = io.vertx.tp.ipc.eon.em.Format.valueOf(responseFormat_);
     return result == null ? io.vertx.tp.ipc.eon.em.Format.UNRECOGNIZED : result;
@@ -179,7 +179,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Category response_category = 2;</code>
    * @return The enum numeric value on the wire for responseCategory.
    */
-  @java.lang.Override public int getResponseCategoryValue() {
+  public int getResponseCategoryValue() {
     return responseCategory_;
   }
   /**
@@ -190,7 +190,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Category response_category = 2;</code>
    * @return The responseCategory.
    */
-  @java.lang.Override public io.vertx.tp.ipc.eon.em.Category getResponseCategory() {
+  public io.vertx.tp.ipc.eon.em.Category getResponseCategory() {
     @SuppressWarnings("deprecation")
     io.vertx.tp.ipc.eon.em.Category result = io.vertx.tp.ipc.eon.em.Category.valueOf(responseCategory_);
     return result == null ? io.vertx.tp.ipc.eon.em.Category.UNRECOGNIZED : result;
@@ -206,7 +206,6 @@ private static final long serialVersionUID = 0L;
    * <code>int32 response_size = 3;</code>
    * @return The responseSize.
    */
-  @java.lang.Override
   public int getResponseSize() {
     return responseSize_;
   }
@@ -221,7 +220,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 4;</code>
    * @return Whether the envelop field is set.
    */
-  @java.lang.Override
   public boolean hasEnvelop() {
     return envelop_ != null;
   }
@@ -233,7 +231,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 4;</code>
    * @return The envelop.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelop getEnvelop() {
     return envelop_ == null ? io.vertx.tp.ipc.eon.IpcEnvelop.getDefaultInstance() : envelop_;
   }
@@ -244,7 +241,6 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 4;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelopOrBuilder getEnvelopOrBuilder() {
     return getEnvelop();
   }
@@ -259,7 +255,6 @@ private static final long serialVersionUID = 0L;
    * <code>bool is_client_id = 5;</code>
    * @return The isClientId.
    */
-  @java.lang.Override
   public boolean getIsClientId() {
     return isClientId_;
   }
@@ -274,7 +269,6 @@ private static final long serialVersionUID = 0L;
    * <code>bool is_oauth_scope = 6;</code>
    * @return The isOauthScope.
    */
-  @java.lang.Override
   public boolean getIsOauthScope() {
     return isOauthScope_;
   }
@@ -289,7 +283,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 7;</code>
    * @return The enum numeric value on the wire for algorithm.
    */
-  @java.lang.Override public int getAlgorithmValue() {
+  public int getAlgorithmValue() {
     return algorithm_;
   }
   /**
@@ -300,7 +294,7 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 7;</code>
    * @return The algorithm.
    */
-  @java.lang.Override public io.vertx.tp.ipc.eon.em.Compression getAlgorithm() {
+  public io.vertx.tp.ipc.eon.em.Compression getAlgorithm() {
     @SuppressWarnings("deprecation")
     io.vertx.tp.ipc.eon.em.Compression result = io.vertx.tp.ipc.eon.em.Compression.valueOf(algorithm_);
     return result == null ? io.vertx.tp.ipc.eon.em.Compression.UNRECOGNIZED : result;
@@ -316,7 +310,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcStatus response_status = 8;</code>
    * @return Whether the responseStatus field is set.
    */
-  @java.lang.Override
   public boolean hasResponseStatus() {
     return responseStatus_ != null;
   }
@@ -328,7 +321,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcStatus response_status = 8;</code>
    * @return The responseStatus.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcStatus getResponseStatus() {
     return responseStatus_ == null ? io.vertx.tp.ipc.eon.IpcStatus.getDefaultInstance() : responseStatus_;
   }
@@ -339,7 +331,6 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.vertx.tp.ipc.eon.IpcStatus response_status = 8;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcStatusOrBuilder getResponseStatusOrBuilder() {
     return getResponseStatus();
   }
@@ -799,7 +790,7 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Format response_format = 1;</code>
      * @return The enum numeric value on the wire for responseFormat.
      */
-    @java.lang.Override public int getResponseFormatValue() {
+    public int getResponseFormatValue() {
       return responseFormat_;
     }
     /**
@@ -812,7 +803,6 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setResponseFormatValue(int value) {
-      
       responseFormat_ = value;
       onChanged();
       return this;
@@ -825,7 +815,6 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Format response_format = 1;</code>
      * @return The responseFormat.
      */
-    @java.lang.Override
     public io.vertx.tp.ipc.eon.em.Format getResponseFormat() {
       @SuppressWarnings("deprecation")
       io.vertx.tp.ipc.eon.em.Format result = io.vertx.tp.ipc.eon.em.Format.valueOf(responseFormat_);
@@ -873,7 +862,7 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Category response_category = 2;</code>
      * @return The enum numeric value on the wire for responseCategory.
      */
-    @java.lang.Override public int getResponseCategoryValue() {
+    public int getResponseCategoryValue() {
       return responseCategory_;
     }
     /**
@@ -886,7 +875,6 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setResponseCategoryValue(int value) {
-      
       responseCategory_ = value;
       onChanged();
       return this;
@@ -899,7 +887,6 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Category response_category = 2;</code>
      * @return The responseCategory.
      */
-    @java.lang.Override
     public io.vertx.tp.ipc.eon.em.Category getResponseCategory() {
       @SuppressWarnings("deprecation")
       io.vertx.tp.ipc.eon.em.Category result = io.vertx.tp.ipc.eon.em.Category.valueOf(responseCategory_);
@@ -947,7 +934,6 @@ private static final long serialVersionUID = 0L;
      * <code>int32 response_size = 3;</code>
      * @return The responseSize.
      */
-    @java.lang.Override
     public int getResponseSize() {
       return responseSize_;
     }
@@ -1145,7 +1131,6 @@ private static final long serialVersionUID = 0L;
      * <code>bool is_client_id = 5;</code>
      * @return The isClientId.
      */
-    @java.lang.Override
     public boolean getIsClientId() {
       return isClientId_;
     }
@@ -1188,7 +1173,6 @@ private static final long serialVersionUID = 0L;
      * <code>bool is_oauth_scope = 6;</code>
      * @return The isOauthScope.
      */
-    @java.lang.Override
     public boolean getIsOauthScope() {
       return isOauthScope_;
     }
@@ -1231,7 +1215,7 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 7;</code>
      * @return The enum numeric value on the wire for algorithm.
      */
-    @java.lang.Override public int getAlgorithmValue() {
+    public int getAlgorithmValue() {
       return algorithm_;
     }
     /**
@@ -1244,7 +1228,6 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setAlgorithmValue(int value) {
-      
       algorithm_ = value;
       onChanged();
       return this;
@@ -1257,7 +1240,6 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 7;</code>
      * @return The algorithm.
      */
-    @java.lang.Override
     public io.vertx.tp.ipc.eon.em.Compression getAlgorithm() {
       @SuppressWarnings("deprecation")
       io.vertx.tp.ipc.eon.em.Compression result = io.vertx.tp.ipc.eon.em.Compression.valueOf(algorithm_);

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcResponse.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcResponse.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.IpcResponse}
  */
-public final class IpcResponse extends
+public  final class IpcResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.IpcResponse)
     IpcResponseOrBuilder {
@@ -117,7 +117,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    * @return Whether the envelop field is set.
    */
-  @java.lang.Override
   public boolean hasEnvelop() {
     return envelop_ != null;
   }
@@ -129,7 +128,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    * @return The envelop.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelop getEnvelop() {
     return envelop_ == null ? io.vertx.tp.ipc.eon.IpcEnvelop.getDefaultInstance() : envelop_;
   }
@@ -140,7 +138,6 @@ private static final long serialVersionUID = 0L;
    *
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelopOrBuilder getEnvelopOrBuilder() {
     return getEnvelop();
   }
@@ -155,7 +152,6 @@ private static final long serialVersionUID = 0L;
    * <code>string client_id = 2;</code>
    * @return The clientId.
    */
-  @java.lang.Override
   public java.lang.String getClientId() {
     java.lang.Object ref = clientId_;
     if (ref instanceof java.lang.String) {
@@ -176,7 +172,6 @@ private static final long serialVersionUID = 0L;
    * <code>string client_id = 2;</code>
    * @return The bytes for clientId.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString
       getClientIdBytes() {
     java.lang.Object ref = clientId_;
@@ -201,7 +196,6 @@ private static final long serialVersionUID = 0L;
    * <code>string oauth_scope = 3;</code>
    * @return The oauthScope.
    */
-  @java.lang.Override
   public java.lang.String getOauthScope() {
     java.lang.Object ref = oauthScope_;
     if (ref instanceof java.lang.String) {
@@ -222,7 +216,6 @@ private static final long serialVersionUID = 0L;
    * <code>string oauth_scope = 3;</code>
    * @return The bytes for oauthScope.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString
       getOauthScopeBytes() {
     java.lang.Object ref = oauthScope_;

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcStatus.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/IpcStatus.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.IpcStatus}
  */
-public final class IpcStatus extends
+public  final class IpcStatus extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.IpcStatus)
     IpcStatusOrBuilder {
@@ -102,7 +102,6 @@ private static final long serialVersionUID = 0L;
    * <code>int32 code = 1;</code>
    * @return The code.
    */
-  @java.lang.Override
   public int getCode() {
     return code_;
   }
@@ -117,7 +116,6 @@ private static final long serialVersionUID = 0L;
    * <code>string message = 2;</code>
    * @return The message.
    */
-  @java.lang.Override
   public java.lang.String getMessage() {
     java.lang.Object ref = message_;
     if (ref instanceof java.lang.String) {
@@ -138,7 +136,6 @@ private static final long serialVersionUID = 0L;
    * <code>string message = 2;</code>
    * @return The bytes for message.
    */
-  @java.lang.Override
   public com.google.protobuf.ByteString
       getMessageBytes() {
     java.lang.Object ref = message_;
@@ -481,7 +478,6 @@ private static final long serialVersionUID = 0L;
      * <code>int32 code = 1;</code>
      * @return The code.
      */
-    @java.lang.Override
     public int getCode() {
       return code_;
     }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/ResponseParams.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/ResponseParams.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.ResponseParams}
  */
-public final class ResponseParams extends
+public  final class ResponseParams extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.ResponseParams)
     ResponseParamsOrBuilder {
@@ -100,7 +100,6 @@ private static final long serialVersionUID = 0L;
    * <code>int32 size = 1;</code>
    * @return The size.
    */
-  @java.lang.Override
   public int getSize() {
     return size_;
   }
@@ -115,7 +114,6 @@ private static final long serialVersionUID = 0L;
    * <code>int32 interval_us = 2;</code>
    * @return The intervalUs.
    */
-  @java.lang.Override
   public int getIntervalUs() {
     return intervalUs_;
   }
@@ -448,7 +446,6 @@ private static final long serialVersionUID = 0L;
      * <code>int32 size = 1;</code>
      * @return The size.
      */
-    @java.lang.Override
     public int getSize() {
       return size_;
     }
@@ -491,7 +488,6 @@ private static final long serialVersionUID = 0L;
      * <code>int32 interval_us = 2;</code>
      * @return The intervalUs.
      */
-    @java.lang.Override
     public int getIntervalUs() {
       return intervalUs_;
     }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/RetryInfo.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/RetryInfo.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.RetryInfo}
  */
-public final class RetryInfo extends
+public  final class RetryInfo extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.RetryInfo)
     RetryInfoOrBuilder {
@@ -121,7 +121,6 @@ private static final long serialVersionUID = 0L;
    * <code>bool passed = 1;</code>
    * @return The passed.
    */
-  @java.lang.Override
   public boolean getPassed() {
     return passed_;
   }
@@ -136,7 +135,6 @@ private static final long serialVersionUID = 0L;
    * <code>repeated int32 backoff_ms = 2;</code>
    * @return A list containing the backoffMs.
    */
-  @java.lang.Override
   public java.util.List<java.lang.Integer>
       getBackoffMsList() {
     return backoffMs_;
@@ -525,7 +523,6 @@ private static final long serialVersionUID = 0L;
      * <code>bool passed = 1;</code>
      * @return The passed.
      */
-    @java.lang.Override
     public boolean getPassed() {
       return passed_;
     }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/RetryParams.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/RetryParams.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.RetryParams}
  */
-public final class RetryParams extends
+public  final class RetryParams extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.RetryParams)
     RetryParamsOrBuilder {
@@ -95,7 +95,6 @@ private static final long serialVersionUID = 0L;
    * <code>int32 max_reconnect = 1;</code>
    * @return The maxReconnect.
    */
-  @java.lang.Override
   public int getMaxReconnect() {
     return maxReconnect_;
   }
@@ -411,7 +410,6 @@ private static final long serialVersionUID = 0L;
      * <code>int32 max_reconnect = 1;</code>
      * @return The maxReconnect.
      */
-    @java.lang.Override
     public int getMaxReconnect() {
       return maxReconnect_;
     }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamClientRequest.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamClientRequest.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.StreamClientRequest}
  */
-public final class StreamClientRequest extends
+public  final class StreamClientRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.StreamClientRequest)
     StreamClientRequestOrBuilder {
@@ -99,7 +99,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    * @return Whether the envelop field is set.
    */
-  @java.lang.Override
   public boolean hasEnvelop() {
     return envelop_ != null;
   }
@@ -107,14 +106,12 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    * @return The envelop.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelop getEnvelop() {
     return envelop_ == null ? io.vertx.tp.ipc.eon.IpcEnvelop.getDefaultInstance() : envelop_;
   }
   /**
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelopOrBuilder getEnvelopOrBuilder() {
     return getEnvelop();
   }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamClientResponse.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamClientResponse.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.StreamClientResponse}
  */
-public final class StreamClientResponse extends
+public  final class StreamClientResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.StreamClientResponse)
     StreamClientResponseOrBuilder {
@@ -91,7 +91,6 @@ private static final long serialVersionUID = 0L;
    * <code>int32 aggregated_size = 1;</code>
    * @return The aggregatedSize.
    */
-  @java.lang.Override
   public int getAggregatedSize() {
     return aggregatedSize_;
   }
@@ -403,7 +402,6 @@ private static final long serialVersionUID = 0L;
      * <code>int32 aggregated_size = 1;</code>
      * @return The aggregatedSize.
      */
-    @java.lang.Override
     public int getAggregatedSize() {
       return aggregatedSize_;
     }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamServerRequest.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamServerRequest.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.StreamServerRequest}
  */
-public final class StreamServerRequest extends
+public  final class StreamServerRequest extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.StreamServerRequest)
     StreamServerRequestOrBuilder {
@@ -140,14 +140,14 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Format response_type = 1;</code>
    * @return The enum numeric value on the wire for responseType.
    */
-  @java.lang.Override public int getResponseTypeValue() {
+  public int getResponseTypeValue() {
     return responseType_;
   }
   /**
    * <code>.io.vertx.tp.ipc.eon.em.Format response_type = 1;</code>
    * @return The responseType.
    */
-  @java.lang.Override public io.vertx.tp.ipc.eon.em.Format getResponseType() {
+  public io.vertx.tp.ipc.eon.em.Format getResponseType() {
     @SuppressWarnings("deprecation")
     io.vertx.tp.ipc.eon.em.Format result = io.vertx.tp.ipc.eon.em.Format.valueOf(responseType_);
     return result == null ? io.vertx.tp.ipc.eon.em.Format.UNRECOGNIZED : result;
@@ -158,14 +158,12 @@ private static final long serialVersionUID = 0L;
   /**
    * <code>repeated .io.vertx.tp.ipc.eon.ResponseParams response_params = 2;</code>
    */
-  @java.lang.Override
   public java.util.List<io.vertx.tp.ipc.eon.ResponseParams> getResponseParamsList() {
     return responseParams_;
   }
   /**
    * <code>repeated .io.vertx.tp.ipc.eon.ResponseParams response_params = 2;</code>
    */
-  @java.lang.Override
   public java.util.List<? extends io.vertx.tp.ipc.eon.ResponseParamsOrBuilder> 
       getResponseParamsOrBuilderList() {
     return responseParams_;
@@ -173,21 +171,18 @@ private static final long serialVersionUID = 0L;
   /**
    * <code>repeated .io.vertx.tp.ipc.eon.ResponseParams response_params = 2;</code>
    */
-  @java.lang.Override
   public int getResponseParamsCount() {
     return responseParams_.size();
   }
   /**
    * <code>repeated .io.vertx.tp.ipc.eon.ResponseParams response_params = 2;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.ResponseParams getResponseParams(int index) {
     return responseParams_.get(index);
   }
   /**
    * <code>repeated .io.vertx.tp.ipc.eon.ResponseParams response_params = 2;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.ResponseParamsOrBuilder getResponseParamsOrBuilder(
       int index) {
     return responseParams_.get(index);
@@ -199,7 +194,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 3;</code>
    * @return Whether the envelop field is set.
    */
-  @java.lang.Override
   public boolean hasEnvelop() {
     return envelop_ != null;
   }
@@ -207,14 +201,12 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 3;</code>
    * @return The envelop.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelop getEnvelop() {
     return envelop_ == null ? io.vertx.tp.ipc.eon.IpcEnvelop.getDefaultInstance() : envelop_;
   }
   /**
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 3;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelopOrBuilder getEnvelopOrBuilder() {
     return getEnvelop();
   }
@@ -225,14 +217,14 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 4;</code>
    * @return The enum numeric value on the wire for algorithm.
    */
-  @java.lang.Override public int getAlgorithmValue() {
+  public int getAlgorithmValue() {
     return algorithm_;
   }
   /**
    * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 4;</code>
    * @return The algorithm.
    */
-  @java.lang.Override public io.vertx.tp.ipc.eon.em.Compression getAlgorithm() {
+  public io.vertx.tp.ipc.eon.em.Compression getAlgorithm() {
     @SuppressWarnings("deprecation")
     io.vertx.tp.ipc.eon.em.Compression result = io.vertx.tp.ipc.eon.em.Compression.valueOf(algorithm_);
     return result == null ? io.vertx.tp.ipc.eon.em.Compression.UNRECOGNIZED : result;
@@ -244,7 +236,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcStatus response_status = 5;</code>
    * @return Whether the responseStatus field is set.
    */
-  @java.lang.Override
   public boolean hasResponseStatus() {
     return responseStatus_ != null;
   }
@@ -252,14 +243,12 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcStatus response_status = 5;</code>
    * @return The responseStatus.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcStatus getResponseStatus() {
     return responseStatus_ == null ? io.vertx.tp.ipc.eon.IpcStatus.getDefaultInstance() : responseStatus_;
   }
   /**
    * <code>.io.vertx.tp.ipc.eon.IpcStatus response_status = 5;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcStatusOrBuilder getResponseStatusOrBuilder() {
     return getResponseStatus();
   }
@@ -703,7 +692,7 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Format response_type = 1;</code>
      * @return The enum numeric value on the wire for responseType.
      */
-    @java.lang.Override public int getResponseTypeValue() {
+    public int getResponseTypeValue() {
       return responseType_;
     }
     /**
@@ -712,7 +701,6 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setResponseTypeValue(int value) {
-      
       responseType_ = value;
       onChanged();
       return this;
@@ -721,7 +709,6 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Format response_type = 1;</code>
      * @return The responseType.
      */
-    @java.lang.Override
     public io.vertx.tp.ipc.eon.em.Format getResponseType() {
       @SuppressWarnings("deprecation")
       io.vertx.tp.ipc.eon.em.Format result = io.vertx.tp.ipc.eon.em.Format.valueOf(responseType_);
@@ -1116,7 +1103,7 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 4;</code>
      * @return The enum numeric value on the wire for algorithm.
      */
-    @java.lang.Override public int getAlgorithmValue() {
+    public int getAlgorithmValue() {
       return algorithm_;
     }
     /**
@@ -1125,7 +1112,6 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setAlgorithmValue(int value) {
-      
       algorithm_ = value;
       onChanged();
       return this;
@@ -1134,7 +1120,6 @@ private static final long serialVersionUID = 0L;
      * <code>.io.vertx.tp.ipc.eon.em.Compression algorithm = 4;</code>
      * @return The algorithm.
      */
-    @java.lang.Override
     public io.vertx.tp.ipc.eon.em.Compression getAlgorithm() {
       @SuppressWarnings("deprecation")
       io.vertx.tp.ipc.eon.em.Compression result = io.vertx.tp.ipc.eon.em.Compression.valueOf(algorithm_);

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamServerResponse.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/StreamServerResponse.java
@@ -6,7 +6,7 @@ package io.vertx.tp.ipc.eon;
 /**
  * Protobuf type {@code io.vertx.tp.ipc.eon.StreamServerResponse}
  */
-public final class StreamServerResponse extends
+public  final class StreamServerResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
     // @@protoc_insertion_point(message_implements:io.vertx.tp.ipc.eon.StreamServerResponse)
     StreamServerResponseOrBuilder {
@@ -99,7 +99,6 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    * @return Whether the envelop field is set.
    */
-  @java.lang.Override
   public boolean hasEnvelop() {
     return envelop_ != null;
   }
@@ -107,14 +106,12 @@ private static final long serialVersionUID = 0L;
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    * @return The envelop.
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelop getEnvelop() {
     return envelop_ == null ? io.vertx.tp.ipc.eon.IpcEnvelop.getDefaultInstance() : envelop_;
   }
   /**
    * <code>.io.vertx.tp.ipc.eon.IpcEnvelop envelop = 1;</code>
    */
-  @java.lang.Override
   public io.vertx.tp.ipc.eon.IpcEnvelopOrBuilder getEnvelopOrBuilder() {
     return getEnvelop();
   }

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/em/Category.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/em/Category.java
@@ -110,10 +110,6 @@ public enum Category
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
-    if (this == UNRECOGNIZED) {
-      throw new java.lang.IllegalStateException(
-          "Can't get the descriptor of an unrecognized enum value.");
-    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/em/Compression.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/em/Compression.java
@@ -110,10 +110,6 @@ public enum Compression
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
-    if (this == UNRECOGNIZED) {
-      throw new java.lang.IllegalStateException(
-          "Can't get the descriptor of an unrecognized enum value.");
-    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor

--- a/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/em/Format.java
+++ b/vertx-istio/zero-iproxy/src/main/java/io/vertx/tp/ipc/eon/em/Format.java
@@ -110,10 +110,6 @@ public enum Format
 
   public final com.google.protobuf.Descriptors.EnumValueDescriptor
       getValueDescriptor() {
-    if (this == UNRECOGNIZED) {
-      throw new java.lang.IllegalStateException(
-          "Can't get the descriptor of an unrecognized enum value.");
-    }
     return getDescriptor().getValues().get(ordinal());
   }
   public final com.google.protobuf.Descriptors.EnumDescriptor


### PR DESCRIPTION
1. Netty -> 4.1.49.Final
2. Guava -> 25.1-jre
3. Google Protobuf -> 3.11.4

> All above version could let duplicated dependency library jars removed, it's needed here. All the graphic of Maven has been managed in zero framework and it's pure now.