### PR TITLE
导出部门/角色等基础管理信息时KeExcel中Shape添加为null判断

### DIFF
--- a/vertx-pin/zero-ke/src/main/java/io/vertx/tp/ke/refine/KeExcel.java
+++ b/vertx-pin/zero-ke/src/main/java/io/vertx/tp/ke/refine/KeExcel.java
@@ -21,7 +21,12 @@ class KeExcel {
                                           final List<String> columns,
                                           final Shape shape) {
         final JsonArray combined = new JsonArray();
-        final boolean complex = shape.isComplex();
+        final boolean complex;
+        if (shape == null) {
+            complex = false;
+        } else {
+            complex = shape.isComplex();
+        }
         /*
          * Header
          * To keep the template is the same as importing, here provide some correction


### PR DESCRIPTION
1，C:\MyApp\vertx-zero\vertx-pin\zero-ke\src\main\java\io\vertx\tp\ke\refine\KeExcel.java
文件中23行，添加Shape为null判断,否则基础管理信息导出时会有空指针异常